### PR TITLE
Added -n, --name argument and conda install.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ conda install -c mforbes conda-tree
 
 ```bash
 # packages that no other package depends on
-$ ./conda-tree.py leafs
+$ ./conda-tree.py leaves
 ['samtools','bcftools',...]
 
 # dependencies of a specific package
@@ -34,6 +34,10 @@ pip -> python -> pip
 pip -> wheel -> python -> pip
 
 # query a different conda prefix/env
-$ ./conda-tree.py -p /conda/envs/trinity leafs
+$ ./conda-tree.py -p /conda/envs/trinity leaves
+['trinity']
+
+# query by name
+$ ./conda-tree.py -n trinity leaves
 ['trinity']
 ```

--- a/README.md
+++ b/README.md
@@ -3,6 +3,16 @@
 
 conda dependency tree helper
 
+# Install
+
+This helper requires only that `conda-tree.py` be on your path and
+that the `conda` and `networkx` packages are installed.  This can be
+done with `conda` itself if you like:
+
+```bash
+conda install -c mforbes conda-tree
+```
+
 # Usage
 
 ```bash

--- a/conda-tree.py
+++ b/conda-tree.py
@@ -47,7 +47,7 @@ def main():
     parser.add_argument('-p','--prefix', default=None)
     parser.add_argument('-n','--name', default=None)
     subparser = parser.add_subparsers(dest='subcmd')
-    subparser.add_parser('leafs', help='shows leaf packages')
+    subparser.add_parser('leaves', help='shows leaf packages')
     subparser.add_parser('cycles', help='shows dependency cycles')
     p = subparser.add_parser('whoneeds', help='shows packages that depends on this package')
     p.add_argument('package', help='the target package')
@@ -86,7 +86,7 @@ def main():
         e = list(map(lambda i: i[0], g.in_edges(args.package)))
         print(e)
 
-    elif args.subcmd == 'leafs':
+    elif args.subcmd in set(['leafs', 'leaves']):
         e = list(map(lambda i:i[0],(filter(lambda i:i[1]==0,g.in_degree()))))
         print(e)
     else:

--- a/conda-tree.py
+++ b/conda-tree.py
@@ -67,6 +67,9 @@ def main():
             [_conda, 'info', '-e', '--json']))
         args.prefix = conda.base.context.locate_prefix_by_name(
             name=args.name, envs_dirs=_info['envs_dirs'])
+
+    if args.prefix is None:
+        args.prefix = sys.prefix
          
     l = get_local_cache(args.prefix)
     g = make_cache_graph(l)

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,0 +1,26 @@
+package:
+  name: conda-tree
+  version: "0.0.1"
+
+source:
+  git_url: https://github.com/mforbes/conda-tree.git
+  git_rev: v0.0.1
+
+requirements:
+  host:
+    - python
+
+  run:
+    - networkx
+    - conda
+
+build:
+  noarch: python
+  script:    # See https://github.com/conda/conda-build/issues/3166
+    - mkdir -p "$PREFIX/bin"
+    - cp conda-tree.py "$PREFIX/bin/"
+    
+about:
+  home: https://github.com/rvalieris/conda-tree
+  license: MIT
+  license_file: LICENSE


### PR DESCRIPTION
I added a conda installable package to my channel, and the ability to specify the environment by name.

Note: there is specifying environments by name is a bit problematic if `conda` is installed again since the newly installed conda may not be able to find environments by the same name that the user expects.  Not sure if there is a better way to do this, but for now I am running the version of `conda` specified by the `CONDA_EXE` environment flag (if it exists) as this is now new versions of conda seem to be executed.