### PR TITLE
Adding a tree view – 0.0.5 proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ $ conda-tree leaves
 $ conda-tree depends samtools
 ['curl', 'xz', 'libgcc', 'zlib']
 
+# dependencies in a tree form
+$ conda-tree depends sqlite
+sqlite==3.29.0
+  - ncurses [required: >=6.1,<6.2.0a0, installed: 6.1]
+    - libcxx [required: >=4.0.1, installed: 8.0.1]
+      - libcxxabi [required: 8.0.1, 0, installed: 8.0.1]
+  - readline [required: >=8.0,<9.0a0, installed: 8.0]
+    - ncurses [required: >=6.1,<6.2.0a0, installed: 6.1]
+      ... (already above)
+
 # which packages depend on a specific package
 $ conda-tree whoneeds xz
 ['samtools', 'bcftools', 'htslib', 'python']
@@ -32,6 +42,20 @@ $ conda-tree whoneeds xz
 $ conda-tree cycles
 pip -> python -> pip
 pip -> wheel -> python -> pip
+
+# full dependency tree
+$ conda-tree deptree --full
+neovim==0.3.1
+  - pynvim [required: Any, installed: 0.3.2]
+    - greenlet [required: Any, installed: 0.4.15]
+    - msgpack-python [required: >=0.5.0, installed: 0.6.1]
+      - libcxx [required: >=4.0.1, installed: 8.0.1]
+        - libcxxabi [required: 8.0.1, 0, installed: 8.0.1]
+conda-tree==0.0.4
+  - conda [required: Any, installed: 4.7.11]
+    - conda-package-handling [required: >=1.3.0, installed: 1.4.1]
+      - libarchive [required: >=3.3.3, installed: 3.3.3]
+...
 
 # query a different conda prefix/env
 $ conda-tree -p /conda/envs/trinity leaves

--- a/README.md
+++ b/README.md
@@ -24,15 +24,16 @@ $ conda-tree leaves
 $ conda-tree depends samtools
 ['curl', 'xz', 'libgcc', 'zlib']
 
-# dependencies in a tree form
-$ conda-tree depends sqlite
+# dependencies in a tree form 
+# (redundancies are hidden by default)
+$ conda-tree depends -t sqlite
 sqlite==3.29.0
-  - ncurses [required: >=6.1,<6.2.0a0, installed: 6.1]
-    - libcxx [required: >=4.0.1, installed: 8.0.1]
-      - libcxxabi [required: 8.0.1, 0, installed: 8.0.1]
-  - readline [required: >=8.0,<9.0a0, installed: 8.0]
-    - ncurses [required: >=6.1,<6.2.0a0, installed: 6.1]
-      ... (already above)
+   ├─ ncurses 6.1 [required: >=6.1,<6.2.0a0]
+   │  └─ libcxx 8.0.1 [required: >=4.0.1]
+   │     └─ libcxxabi 8.0.1 [required: 8.0.1, 0]
+   └─ readline 8.0 [required: >=8.0,<9.0a0]
+      └─ ncurses 6.1 [required: >=6.1,<6.2.0a0]
+         └─ dependencies of ncurses displayed above
 
 # which packages depend on a specific package
 $ conda-tree whoneeds xz
@@ -46,15 +47,15 @@ pip -> wheel -> python -> pip
 # full dependency tree
 $ conda-tree deptree --full
 neovim==0.3.1
-  - pynvim [required: Any, installed: 0.3.2]
-    - greenlet [required: Any, installed: 0.4.15]
-    - msgpack-python [required: >=0.5.0, installed: 0.6.1]
-      - libcxx [required: >=4.0.1, installed: 8.0.1]
-        - libcxxabi [required: 8.0.1, 0, installed: 8.0.1]
+   └─ pynvim 0.3.2 [required: any]
+      ├─ greenlet 0.4.15 [required: any]
+      └─ msgpack-python 0.6.1 [required: >=0.5.0]
+         └─ libcxx 8.0.1 [required: >=4.0.1]
+            └─ libcxxabi 8.0.1 [required: 8.0.1, 0]
 conda-tree==0.0.4
-  - conda [required: Any, installed: 4.7.11]
-    - conda-package-handling [required: >=1.3.0, installed: 1.4.1]
-      - libarchive [required: >=3.3.3, installed: 3.3.3]
+   ├─ conda 4.7.11 [required: any]
+   │  ├─ conda-package-handling 1.4.1 [required: >=1.3.0]
+   │  │  ├─ libarchive 3.3.3 [required: >=3.3.3]
 ...
 
 # query a different conda prefix/env

--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ $ conda-tree depends samtools
 # (redundancies are hidden by default)
 $ conda-tree depends -t sqlite
 sqlite==3.29.0
-   ├─ ncurses 6.1 [required: >=6.1,<6.2.0a0]
-   │  └─ libcxx 8.0.1 [required: >=4.0.1]
-   │     └─ libcxxabi 8.0.1 [required: 8.0.1, 0]
-   └─ readline 8.0 [required: >=8.0,<9.0a0]
-      └─ ncurses 6.1 [required: >=6.1,<6.2.0a0]
-         └─ dependencies of ncurses displayed above
+  ├─ ncurses 6.1 [required: >=6.1,<6.2.0a0]
+  │  └─ libcxx 8.0.1 [required: >=4.0.1]
+  │     └─ libcxxabi 8.0.1 [required: 8.0.1, 0]
+  └─ readline 8.0 [required: >=8.0,<9.0a0]
+     └─ ncurses 6.1 [required: >=6.1,<6.2.0a0]
+       └─ dependencies of ncurses displayed above
 
 # which packages depend on a specific package
 $ conda-tree whoneeds xz
@@ -47,15 +47,16 @@ pip -> wheel -> python -> pip
 # full dependency tree
 $ conda-tree deptree --full
 neovim==0.3.1
-   └─ pynvim 0.3.2 [required: any]
-      ├─ greenlet 0.4.15 [required: any]
-      └─ msgpack-python 0.6.1 [required: >=0.5.0]
-         └─ libcxx 8.0.1 [required: >=4.0.1]
-            └─ libcxxabi 8.0.1 [required: 8.0.1, 0]
+  └─ pynvim 0.3.2 [required: any]
+     ├─ greenlet 0.4.15 [required: any]
+     └─ msgpack-python 0.6.1 [required: >=0.5.0]
+        └─ libcxx 8.0.1 [required: >=4.0.1]
+           └─ libcxxabi 8.0.1 [required: 8.0.1, 0]
 conda-tree==0.0.4
-   ├─ conda 4.7.11 [required: any]
-   │  ├─ conda-package-handling 1.4.1 [required: >=1.3.0]
-   │  │  ├─ libarchive 3.3.3 [required: >=3.3.3]
+  ├─ conda 4.7.11 [required: any]
+  │  ├─ conda-package-handling 1.4.1 [required: >=1.3.0]
+  │  │  ├─ libarchive 3.3.3 [required: >=3.3.3]
+  │  │  │  ├─ bzip2 1.0.8 [required: >=1.0.6,<2.0a0]
 ...
 
 # query a different conda prefix/env

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ sqlite==3.29.0
   │     └─ libcxxabi 8.0.1 [required: 8.0.1, 0]
   └─ readline 8.0 [required: >=8.0,<9.0a0]
      └─ ncurses 6.1 [required: >=6.1,<6.2.0a0]
-       └─ dependencies of ncurses displayed above
+        └─ dependencies of ncurses displayed above
 
 # which packages depend on a specific package
 $ conda-tree whoneeds xz
@@ -47,11 +47,14 @@ pip -> wheel -> python -> pip
 # full dependency tree
 $ conda-tree deptree --full
 neovim==0.3.1
-  └─ pynvim 0.3.2 [required: any]
-     ├─ greenlet 0.4.15 [required: any]
-     └─ msgpack-python 0.6.1 [required: >=0.5.0]
-        └─ libcxx 8.0.1 [required: >=4.0.1]
-           └─ libcxxabi 8.0.1 [required: 8.0.1, 0]
+  ├─ pynvim 0.3.2 [required: any]
+  │  ├─ greenlet 0.4.15 [required: any]
+  │  │  └─ python 3.7.3 [required: >=3.7,<3.8.0a0]
+  │  │     ├─ bzip2 1.0.8 [required: >=1.0.6,<2.0a0]
+  │  │     ├─ libcxx 8.0.1 [required: >=4.0.1]
+  │  │     │  └─ libcxxabi 8.0.1 [required: 8.0.1, 0]
+  │  │     ├─ libffi 3.2.1 [required: >=3.2.1,<3.3.0a0]
+...
 conda-tree==0.0.4
   ├─ conda 4.7.11 [required: any]
   │  ├─ conda-package-handling 1.4.1 [required: >=1.3.0]

--- a/conda-tree.py
+++ b/conda-tree.py
@@ -9,103 +9,161 @@ import subprocess
 import conda.exports
 import networkx
 
-__version__ = '0.0.4'
+__version__ = '0.0.5'
 
 def get_local_cache(prefix):
-    return conda.exports.linked_data(prefix=prefix)
+	return conda.exports.linked_data(prefix=prefix)
 
 def get_package_key(cache, package_name):
-    ks = list(filter(lambda i: l[i]['name'] == package_name, l))
-    return ks[0]
+	ks = list(filter(lambda i: l[i]['name'] == package_name, l))
+	return ks[0]
 
-def make_cache_graph(cache):
+def make_cache_graph(cache, no_python):
 	g = networkx.DiGraph()
 	for k in cache.keys():
 		n = cache[k]['name']
-		g.add_node(n)
+		v = cache[k]['version']
+		# Removing python to avoid cycles (--tree option)
+		if no_python and n == "python": continue
+		g.add_node(n, version=v)
 		for j in cache[k]['depends']:
 			n2 = j.split(' ')[0]
-			g.add_edge(n, n2)
+			v2 = j.split(' ')[1:]
+			g.add_edge(n, n2, version=v2)
 	return(g)
 
 def print_graph_dot(g):
-    print("digraph {")
-    for k,v in g.edges():
-       print("  \"{}\" -> \"{}\"".format(k,v))
-    print("}")
+	print("digraph {")
+	for k,v in g.edges():
+	   print("  \"{}\" -> \"{}\"".format(k,v))
+	print("}")
 
 def remove_from_graph(g, node, _cache=None):
-    if _cache is None: _cache = {}
-    if node not in _cache:
-        _cache[node] = True
-        for k,v in g.out_edges(node):
-            g = remove_from_graph(g, v, _cache)
-    if node in g: g.remove_node(node)
-    return(g)
+	if _cache is None: _cache = {}
+	if node not in _cache:
+		_cache[node] = True
+		for k,v in g.out_edges(node):
+			g = remove_from_graph(g, v, _cache)
+	if node in g: g.remove_node(node)
+	return(g)
+
+def print_dependencies(g, pkg, parent, indent, args, treated):
+	s = "" # String to print
+	v = g.nodes[pkg]['version']
+	out_edges = g.out_edges(pkg)
+	e = [i[1] for i in out_edges]
+	# Removing python to avoid cycles
+	if "python" in e: e.remove("python")
+	if args.no_conda and "conda" in e: e.remove("conda")
+	if indent == 0:
+		s += f"{pkg}=={v}\n"
+	else:
+		r = ', '.join(g.edges[parent, pkg]['version'])
+		r = 'Any' if r == '' else r
+		i_str = '  ' * indent
+		s += f"{i_str}- {pkg} [required: {r}, installed: {v}]\n"
+		if pkg in treated and not args.full:
+			s += f"{i_str}  ... (already above)\n"
+			return s, treated
+		else:
+			if len(e) > 0: treated.add(pkg)
+	for pack in e: 
+		tree_str, treat = print_dependencies(g, pack, pkg, indent+1, args, treated)
+		s += tree_str
+		for pkg_name in treat: treated.add(pkg_name)
+	return s, treated
 
 def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument('-p','--prefix', default=None)
-    parser.add_argument('-n','--name', default=None)
-    parser.add_argument('-v','--version', action='version', version='%(prog)s '+__version__)
-    parser.add_argument('-r','--recursive', help='show dependencies of dependencies',default=False, action='store_true')
-    subparser = parser.add_subparsers(dest='subcmd')
-    subparser.add_parser('leaves', help='shows leaf packages')
-    subparser.add_parser('cycles', help='shows dependency cycles')
-    p = subparser.add_parser('whoneeds', help='shows packages that depends on this package')
-    p.add_argument('package', help='the target package')
-    p = subparser.add_parser('depends', help='shows this package dependencies')
-    p.add_argument('package', help='the target package')
-    args = parser.parse_args()
+	parser = argparse.ArgumentParser()
+	parser.add_argument('-p','--prefix', default=None)
+	parser.add_argument('-n','--name', default=None)
+	parser.add_argument('-v','--version', action='version', version='%(prog)s '+__version__)
 
-    if args.name is not None:
-        # Allow user to specify name, but check the environment for an
-        # existing CONDA_EXE command.  This allows a different conda
-        # package to be installed (and imported above) but will
-        # resolve the name using their expected conda.  (The imported
-        # conda here will find the environments, but might not name
-        # them as the user expects.)
-        _conda = os.environ.get('CONDA_EXE', 'conda')
-        _info = json.loads(subprocess.check_output(
-            [_conda, 'info', '-e', '--json']))
-        args.prefix = conda.base.context.locate_prefix_by_name(
-            name=args.name, envs_dirs=_info['envs_dirs'])
+	subparser = parser.add_subparsers(dest='subcmd')
+	subparser.add_parser('leaves', help='shows leaf packages')
+	subparser.add_parser('cycles', help='shows dependency cycles')
 
-    if args.prefix is None:
-        args.prefix = sys.prefix
-         
-    l = get_local_cache(args.prefix)
-    g = make_cache_graph(l)
+	package_cmds = argparse.ArgumentParser(add_help=False)
+	package_cmds.add_argument('package', help='the target package')
 
-    if args.subcmd == 'cycles':
-        for i in networkx.simple_cycles(g):
-            print(" -> ".join(i)+" -> "+i[0])
+	rec_or_tree = package_cmds.add_mutually_exclusive_group(required=False)
+	rec_or_tree.add_argument('-t', '--tree', help='show dependencies of dependencies in tree form, ignores python as a dependency to avoid cycles', default=False, action="store_true")
+	rec_or_tree.add_argument('-r','--recursive', help='show dependencies of dependencies',default=False, action='store_true')
 
-    elif args.subcmd == 'depends':
-        if args.package not in g:
-            print("warning: package \"%s\" not found"%(args.package), file=sys.stderr)
-        if args.recursive:
-            e = list(networkx.descendants(g, args.package))
-        else:
-            e = list(map(lambda i: i[1], g.out_edges(args.package)))
-        print(e)
+	hiding_cmds = argparse.ArgumentParser(add_help=False)
+	hiding_cmds.add_argument('--no-conda', help='does not show dependencies of conda to make the tree easier to understand', default=False, action='store_true')
+	hiding_cmds.add_argument('--full', help='shows the complete dependency tree, with all the repetitions that it entails', default=False, action='store_true')
 
-    elif args.subcmd == 'whoneeds':
-        if args.package not in g:
-            print("warning: package \"%s\" not found"%(args.package), file=sys.stderr)
-        if args.recursive:
-            e = list(networkx.ancestors(g, args.package))
-        else:
-            e = list(map(lambda i: i[0], g.in_edges(args.package)))
-        print(e)
+	subparser.add_parser('whoneeds', help='shows packages that depends on this package', parents=[package_cmds, hiding_cmds])
+	subparser.add_parser('depends', help='shows this package dependencies', parents=[package_cmds, hiding_cmds])
+	subparser.add_parser('deptree', help="shows the complete dependency tree ('python' is excluded to avoid cycles)", parents=[hiding_cmds])
 
-    elif args.subcmd == 'leaves':
-        e = list(map(lambda i:i[0],(filter(lambda i:i[1]==0,g.in_degree()))))
-        print(e)
-    else:
-        parser.print_help()
-        sys.exit(1)
+	args = parser.parse_args()
+
+	if args.name is not None:
+		# Allow user to specify name, but check the environment for an
+		# existing CONDA_EXE command.  This allows a different conda
+		# package to be installed (and imported above) but will
+		# resolve the name using their expected conda.  (The imported
+		# conda here will find the environments, but might not name
+		# them as the user expects.)
+		_conda = os.environ.get('CONDA_EXE', 'conda')
+		_info = json.loads(subprocess.check_output(
+			[_conda, 'info', '-e', '--json']))
+		args.prefix = conda.base.context.locate_prefix_by_name(
+			name=args.name, envs_dirs=_info['envs_dirs'])
+
+	if args.prefix is None:
+		args.prefix = sys.prefix
+		 
+	l = get_local_cache(args.prefix)
+	no_python = True if (args.subcmd == "deptree" or args.tree) else False
+	g = make_cache_graph(l, no_python)
+
+	def get_leaves(graph):
+		return list(map(lambda i:i[0],(filter(lambda i:i[1]==0,graph.in_degree()))))
+
+	if args.subcmd == 'cycles':
+		for i in networkx.simple_cycles(g):
+			print(" -> ".join(i)+" -> "+i[0])
+
+	elif args.subcmd == 'depends':
+		if args.package not in g:
+			print("warning: package \"%s\" not found"%(args.package), file=sys.stderr)
+		if args.recursive:
+			e = list(networkx.descendants(g, args.package))
+			print(e)
+		elif args.tree:
+			if networkx.is_directed_acyclic_graph(g):
+				tree, _ = print_dependencies(g, args.package, None, 0, args, set())
+				print(tree)
+		else:
+			e = list(map(lambda i: i[1], g.out_edges(args.package)))
+			print(e)
+
+	elif args.subcmd == 'whoneeds':
+		if args.package not in g:
+			print("warning: package \"%s\" not found"%(args.package), file=sys.stderr)
+		if args.recursive:
+			e = list(networkx.ancestors(g, args.package))
+		else:
+			e = list(map(lambda i: i[0], g.in_edges(args.package)))
+		print(e)
+
+	elif args.subcmd == 'leaves':
+		print(get_leaves(g))
+
+	elif args.subcmd == 'deptree':
+		treated = set()
+		complete_tree = ""
+		for pk in get_leaves(g):
+			tree, treated = print_dependencies(g, pk, None, 0, args, treated)
+			complete_tree += tree
+		print(''.join(complete_tree))
+	else:
+		parser.print_help()
+		sys.exit(1)
 
 if __name__ == "__main__":
-    main()
+	main()
 

--- a/conda-tree.py
+++ b/conda-tree.py
@@ -188,7 +188,7 @@ def main():
                 print("Error: The dependency graph is cyclical.")
         else:
             fn = g.out_edges if down_search else g.in_edges
-            e = list(map(lambda i: i[1], fn(args.package)))
+            e = list(map(lambda i: i[1] if down_search else i[0], fn(args.package)))
             print(e)
 
     elif args.subcmd == 'leaves':

--- a/conda-tree.py
+++ b/conda-tree.py
@@ -148,8 +148,8 @@ def main():
     # To know when we have to hide python from the dependency graph
     # In other words, when do we need to have a graph that is not
     # cyclical?
-    no_python = True if (args.subcmd not in ["cycles", "leaves"] 
-                         and args.tree) else False
+    no_python = True if (args.subcmd == "deptree" or
+                        (hasattr(args, "tree") and args.tree)) else False
     g = make_cache_graph(l, no_python)
 
     ######

--- a/conda-tree.py
+++ b/conda-tree.py
@@ -208,9 +208,6 @@ def main():
         args.prefix = sys.prefix
          
     l = get_local_cache(args.prefix)
-    # To know when we have to hide python from the dependency graph
-    # In other words, when do we need to have a graph that is not
-    # cyclical?
     g = make_cache_graph(l)
 
     ######
@@ -272,7 +269,7 @@ def main():
         sys.exit(1)
 
     #######
-    # Warning messages
+    # End warning messages
     #######
 
     # If we use a tree-based command without --full enabled

--- a/conda-tree.py
+++ b/conda-tree.py
@@ -12,199 +12,199 @@ import networkx
 __version__ = '0.0.5'
 
 def get_local_cache(prefix):
-	return conda.exports.linked_data(prefix=prefix)
+    return conda.exports.linked_data(prefix=prefix)
 
 def get_package_key(cache, package_name):
-	ks = list(filter(lambda i: l[i]['name'] == package_name, l))
-	return ks[0]
+    ks = list(filter(lambda i: l[i]['name'] == package_name, l))
+    return ks[0]
 
 def make_cache_graph(cache, no_python):
-	g = networkx.DiGraph()
-	for k in cache.keys():
-		n = cache[k]['name']
-		v = cache[k]['version']
-		# Removing python to avoid cycles (--tree option)
-		if no_python and n == "python": continue
-		g.add_node(n, version=v)
-		for j in cache[k]['depends']:
-			n2 = j.split(' ')[0]
-			v2 = j.split(' ')[1:]
-			g.add_edge(n, n2, version=v2)
-	return(g)
+    g = networkx.DiGraph()
+    for k in cache.keys():
+        n = cache[k]['name']
+        v = cache[k]['version']
+        # Removing python to avoid cycles (--tree option)
+        if no_python and n == "python": continue
+        g.add_node(n, version=v)
+        for j in cache[k]['depends']:
+            n2 = j.split(' ')[0]
+            v2 = j.split(' ')[1:]
+            g.add_edge(n, n2, version=v2)
+    return(g)
 
 def print_graph_dot(g):
-	print("digraph {")
-	for k,v in g.edges():
-	   print("  \"{}\" -> \"{}\"".format(k,v))
-	print("}")
+    print("digraph {")
+    for k,v in g.edges():
+       print("  \"{}\" -> \"{}\"".format(k,v))
+    print("}")
 
 def remove_from_graph(g, node, _cache=None):
-	if _cache is None: _cache = {}
-	if node not in _cache:
-		_cache[node] = True
-		for k,v in g.out_edges(node):
-			g = remove_from_graph(g, v, _cache)
-	if node in g: g.remove_node(node)
-	return(g)
+    if _cache is None: _cache = {}
+    if node not in _cache:
+        _cache[node] = True
+        for k,v in g.out_edges(node):
+            g = remove_from_graph(g, v, _cache)
+    if node in g: g.remove_node(node)
+    return(g)
 
 def print_dependencies(g, pkg, parent, indent, args, processed, down_search):
-	s = "" # String to print
-	v = g.nodes[pkg]['version']
-	edges = g.out_edges(pkg) if down_search else g.in_edges(pkg)
-	e = [i[1] for i in edges] if down_search else [i[0] for i in edges]
-	# Removing python to avoid cycles
-	if "python" in e: e.remove("python")
-	if args.no_conda and "conda" in e: e.remove("conda")
-	if indent == 0:
-		s += f"{pkg}=={v}\n"
-	else:
-		r = (', '.join(g.edges[parent, pkg]['version']) if down_search
-			 else ', '.join(g.edges[pkg, parent]['version']))
-		r = 'Any' if r == '' else r
-		i_str = '  ' * indent
-		s += f"{i_str}- {pkg} [required: {r}, installed: {v}]\n"
-		if pkg in processed and not args.full:
-			s += f"{i_str}  ... (already above)\n"
-			return s, processed
-		else:
-			if len(e) > 0: processed.add(pkg)
-	for pack in e: 
-		tree_str, treat = print_dependencies(
-			g, pack, pkg, indent+1, args, processed, down_search)
-		s += tree_str
-		for pkg_name in treat: processed.add(pkg_name)
-	return s, processed
+    s = "" # String to print
+    v = g.nodes[pkg]['version']
+    edges = g.out_edges(pkg) if down_search else g.in_edges(pkg)
+    e = [i[1] for i in edges] if down_search else [i[0] for i in edges]
+    # Removing python to avoid cycles
+    if "python" in e: e.remove("python")
+    if args.no_conda and "conda" in e: e.remove("conda")
+    if indent == 0:
+        s += f"{pkg}=={v}\n"
+    else:
+        r = (', '.join(g.edges[parent, pkg]['version']) if down_search
+             else ', '.join(g.edges[pkg, parent]['version']))
+        r = 'Any' if r == '' else r
+        i_str = '  ' * indent
+        s += f"{i_str}- {pkg} [required: {r}, installed: {v}]\n"
+        if pkg in processed and not args.full:
+            s += f"{i_str}  ... (already above)\n"
+            return s, processed
+        else:
+            if len(e) > 0: processed.add(pkg)
+    for pack in e: 
+        tree_str, treat = print_dependencies(
+            g, pack, pkg, indent+1, args, processed, down_search)
+        s += tree_str
+        for pkg_name in treat: processed.add(pkg_name)
+    return s, processed
 
 def main():
-	parser = argparse.ArgumentParser()
-	parser.add_argument('-p','--prefix', default=None)
-	parser.add_argument('-n','--name', default=None)
-	parser.add_argument('-v','--version', action='version', version='%(prog)s '+__version__)
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-p','--prefix', default=None)
+    parser.add_argument('-n','--name', default=None)
+    parser.add_argument('-v','--version', action='version', version='%(prog)s '+__version__)
 
-	subparser = parser.add_subparsers(dest='subcmd')
+    subparser = parser.add_subparsers(dest='subcmd')
 
-	# Arguments for "package_cmds" commands
-	# Subcommands that deal with the dependencies of packages
-	package_cmds = argparse.ArgumentParser(add_help=False)
-	package_cmds.add_argument('package', help='the target package')
+    # Arguments for "package_cmds" commands
+    # Subcommands that deal with the dependencies of packages
+    package_cmds = argparse.ArgumentParser(add_help=False)
+    package_cmds.add_argument('package', help='the target package')
 
-	# Arguments for "rec_or_tree" commands
-	# Subcommands that can yield direct dependencies, recursive dependencies, or a tree view
-	rec_or_tree = package_cmds.add_mutually_exclusive_group(required=False)
-	rec_or_tree.add_argument('-t', '--tree', 
-		help=('show dependencies of dependencies in tree form, ' +
-			  'ignores python as a dependency to avoid cycles'), 
-		default=False, action="store_true")
-	rec_or_tree.add_argument('-r','--recursive', 
-		help='show dependencies of dependencies',
-		default=False, action='store_true')
+    # Arguments for "rec_or_tree" commands
+    # Subcommands that can yield direct dependencies, recursive dependencies, or a tree view
+    rec_or_tree = package_cmds.add_mutually_exclusive_group(required=False)
+    rec_or_tree.add_argument('-t', '--tree', 
+        help=('show dependencies of dependencies in tree form, ' +
+              'ignores python as a dependency to avoid cycles'), 
+        default=False, action="store_true")
+    rec_or_tree.add_argument('-r','--recursive', 
+        help='show dependencies of dependencies',
+        default=False, action='store_true')
 
-	# Arguments for "hiding" commands
-	# Subcommands that enable users to hide a part of the result
-	hiding_cmds = argparse.ArgumentParser(add_help=False)
-	hiding_cmds.add_argument('--no-conda', 
-		help=('does not show dependencies of conda' +
-			  'to make the tree easier to understand'), 
-		default=False, action='store_true')
-	hiding_cmds.add_argument('--full', 
-		help=('shows the complete dependency tree,' +
-			  'with all the repetitions that it entails'), 
-		default=False, action='store_true')
+    # Arguments for "hiding" commands
+    # Subcommands that enable users to hide a part of the result
+    hiding_cmds = argparse.ArgumentParser(add_help=False)
+    hiding_cmds.add_argument('--no-conda', 
+        help=('does not show dependencies of conda' +
+              'to make the tree easier to understand'), 
+        default=False, action='store_true')
+    hiding_cmds.add_argument('--full', 
+        help=('shows the complete dependency tree,' +
+              'with all the repetitions that it entails'), 
+        default=False, action='store_true')
 
-	# Definining the simple subcommands
-	subparser.add_parser('leaves', help='shows leaf packages')
-	subparser.add_parser('cycles', help='shows dependency cycles')
+    # Definining the simple subcommands
+    subparser.add_parser('leaves', help='shows leaf packages')
+    subparser.add_parser('cycles', help='shows dependency cycles')
 
-	# Defining the complex subcommands
-	subparser.add_parser('whoneeds', 
-		help='shows packages that depends on this package', 
-		parents=[package_cmds, hiding_cmds])
-	subparser.add_parser('depends', 
-		help='shows this package dependencies',
-		parents=[package_cmds, hiding_cmds])
-	subparser.add_parser('deptree',
-		help="shows the complete dependency tree ('python' is excluded to avoid cycles)",
-		parents=[hiding_cmds])
+    # Defining the complex subcommands
+    subparser.add_parser('whoneeds', 
+        help='shows packages that depends on this package', 
+        parents=[package_cmds, hiding_cmds])
+    subparser.add_parser('depends', 
+        help='shows this package dependencies',
+        parents=[package_cmds, hiding_cmds])
+    subparser.add_parser('deptree',
+        help="shows the complete dependency tree ('python' is excluded to avoid cycles)",
+        parents=[hiding_cmds])
 
-	args = parser.parse_args()
+    args = parser.parse_args()
 
-	if args.name is not None:
-		# Allow user to specify name, but check the environment for an
-		# existing CONDA_EXE command.  This allows a different conda
-		# package to be installed (and imported above) but will
-		# resolve the name using their expected conda.  (The imported
-		# conda here will find the environments, but might not name
-		# them as the user expects.)
-		_conda = os.environ.get('CONDA_EXE', 'conda')
-		_info = json.loads(subprocess.check_output(
-			[_conda, 'info', '-e', '--json']))
-		args.prefix = conda.base.context.locate_prefix_by_name(
-			name=args.name, envs_dirs=_info['envs_dirs'])
+    if args.name is not None:
+        # Allow user to specify name, but check the environment for an
+        # existing CONDA_EXE command.  This allows a different conda
+        # package to be installed (and imported above) but will
+        # resolve the name using their expected conda.  (The imported
+        # conda here will find the environments, but might not name
+        # them as the user expects.)
+        _conda = os.environ.get('CONDA_EXE', 'conda')
+        _info = json.loads(subprocess.check_output(
+            [_conda, 'info', '-e', '--json']))
+        args.prefix = conda.base.context.locate_prefix_by_name(
+            name=args.name, envs_dirs=_info['envs_dirs'])
 
-	if args.prefix is None:
-		args.prefix = sys.prefix
-		 
-	l = get_local_cache(args.prefix)
-	# To know when we have to hide python from the dependency graph
-	# In other words, when do we need to have a graph that is not
-	# cyclical?
-	no_python = True if (args.subcmd not in ["cycles", "leaves"] 
-						 and args.tree) else False
-	g = make_cache_graph(l, no_python)
+    if args.prefix is None:
+        args.prefix = sys.prefix
+         
+    l = get_local_cache(args.prefix)
+    # To know when we have to hide python from the dependency graph
+    # In other words, when do we need to have a graph that is not
+    # cyclical?
+    no_python = True if (args.subcmd not in ["cycles", "leaves"] 
+                         and args.tree) else False
+    g = make_cache_graph(l, no_python)
 
-	######
-	# Helper functions for subcommands
-	######
-	def get_leaves(graph):
-		return list(map(lambda i:i[0],(filter(lambda i:i[1]==0,graph.in_degree()))))
+    ######
+    # Helper functions for subcommands
+    ######
+    def get_leaves(graph):
+        return list(map(lambda i:i[0],(filter(lambda i:i[1]==0,graph.in_degree()))))
 
-	def get_cycles(graph):
-		s = ""
-		for i in networkx.simple_cycles(graph):
-			s += " -> ".join(i)+" -> "+i[0] + "\n"
-		return s
+    def get_cycles(graph):
+        s = ""
+        for i in networkx.simple_cycles(graph):
+            s += " -> ".join(i)+" -> "+i[0] + "\n"
+        return s
 
-	if args.subcmd == 'cycles':
-		print(get_cycles(g), end='')
+    if args.subcmd == 'cycles':
+        print(get_cycles(g), end='')
 
-	elif args.subcmd in ['depends', 'whoneeds']:
-		# This variable defines whether we are searching down the dependency
-		# tree, or if rather we are looking for which packages depend on the 
-		# package, which would be searching up.
-		# The 'depends' subcommand corresponds to a down search.
-		down_search = (args.subcmd == "depends")
-		if args.package not in g:
-			print("warning: package \"%s\" not found"%(args.package), file=sys.stderr)
-		if args.recursive:
-			fn = networkx.descendants if down_search else networkx.ancestors
-			e = list(fn(g, args.package))
-			print(e)
-		elif args.tree:
-			if networkx.is_directed_acyclic_graph(g):
-				tree, _ = print_dependencies(
-					g, args.package, None, 0, args, set(), down_search)
-				print(tree)
-			else: 
-				print("Error: The dependency graph is cyclical.")
-		else:
-			fn = g.out_edges if down_search else g.in_edges
-			e = list(map(lambda i: i[1], fn(args.package)))
-			print(e)
+    elif args.subcmd in ['depends', 'whoneeds']:
+        # This variable defines whether we are searching down the dependency
+        # tree, or if rather we are looking for which packages depend on the 
+        # package, which would be searching up.
+        # The 'depends' subcommand corresponds to a down search.
+        down_search = (args.subcmd == "depends")
+        if args.package not in g:
+            print("warning: package \"%s\" not found"%(args.package), file=sys.stderr)
+        if args.recursive:
+            fn = networkx.descendants if down_search else networkx.ancestors
+            e = list(fn(g, args.package))
+            print(e)
+        elif args.tree:
+            if networkx.is_directed_acyclic_graph(g):
+                tree, _ = print_dependencies(
+                    g, args.package, None, 0, args, set(), down_search)
+                print(tree)
+            else: 
+                print("Error: The dependency graph is cyclical.")
+        else:
+            fn = g.out_edges if down_search else g.in_edges
+            e = list(map(lambda i: i[1], fn(args.package)))
+            print(e)
 
-	elif args.subcmd == 'leaves':
-		print(get_leaves(g))
+    elif args.subcmd == 'leaves':
+        print(get_leaves(g))
 
-	elif args.subcmd == 'deptree':
-		processed, complete_tree = set(), ""
-		for pk in get_leaves(g):
-			tree, processed = print_dependencies(
-				g, pk, None, 0, args, processed, True)
-			complete_tree += tree
-		print(''.join(complete_tree))
-	else:
-		parser.print_help()
-		sys.exit(1)
+    elif args.subcmd == 'deptree':
+        processed, complete_tree = set(), ""
+        for pk in get_leaves(g):
+            tree, processed = print_dependencies(
+                g, pk, None, 0, args, processed, True)
+            complete_tree += tree
+        print(''.join(complete_tree))
+    else:
+        parser.print_help()
+        sys.exit(1)
 
 if __name__ == "__main__":
-	main()
+    main()
 

--- a/conda-tree.py
+++ b/conda-tree.py
@@ -82,6 +82,7 @@ def print_dep_tree(g, pkg, prev, state):
             # or, if '--full' is used, a special case for python.
         else False)
     will_create_subtree = (True if len(e) >= 1 else False)
+    if len(e) > 0: state["tree_exists"].add(pkg)
 
     # If the package is a leaf
     if indent == 0:

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: conda-tree
-  version: "0.0.4"
+  version: "0.0.5"
 
 source:
   git_url: https://github.com/rvalieris/conda-tree.git
-  git_rev: v0.0.4
+  git_rev: v0.0.5
 
 requirements:
   host:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import shutil
 shutil.copyfile('conda-tree.py', 'conda_tree.py')
 
 setup(name='conda-tree',
-      version='0.0.4',
+      version='0.0.5',
       description='conda dependency tree helper',
       author='Renan Valieris',
       url='https://github.com/rvalieris/conda-tree',


### PR DESCRIPTION
Hi @rvalieris, thank you so much for this project! I wrote a few adjustments to `conda-tree`, tell me what you think:

### Tree view

I kind of wanted to merge the best of `pipdeptree` and `conda-tree`, and so I took the liberty of forking your repo and add the tree view functionality.

It works by adding a `-t/--tree` option:

```
$ python conda-tree.py depends -t sqlite 
sqlite==3.29.0
  - ncurses [required: >=6.1,<6.2.0a0, installed: 6.1]
    - libcxx [required: >=4.0.1, installed: 8.0.1]
      - libcxxabi [required: 8.0.1, 0, installed: 8.0.1]
  - readline [required: >=8.0,<9.0a0, installed: 8.0]
    - ncurses [required: >=6.1,<6.2.0a0, installed: 6.1]
      ... (already above)
```

A few notes:
1. It also works with `whoneeds`.
2. You perhaps noticed that displaying the dependencies `ncurses` would be redundant. Hence, these dependencies are displayed once, and then hidden by default for the rest of the tree. There is a `--full` option to halt this behavior.
3. `-t` and `-r` are mutually exclusive, and `-r`'s behavior is unchanged.
4. To avoid cycles, I removed the `python` package from the graph. (Of course, not every conda package relies on python, but that was the only way I found to not break everything.)

### `deptree` subcommand

There is now a `deptree` subcommand, that displays the full dependency tree. This is where hiding redundant dependencies becomes really practical. (It essentially repeats `conda-tree -t depends` for every package in `conda-tree leaves`). 

There is a `--no-conda` option to avoid `conda` from the dependency tree; then you can truly have an idea of what came _on top_ of the default install.

### Refactoring

I refactored a few things in the code to avoid repetitions. The argparse parser is a little more complex, but more hierarchical. For instance, it knows that `-r` only applies to functions relative to packages, and so on.