### PR TITLE
remove '-e' option when getting the conda env info: fixes #27

### DIFF
--- a/conda-tree.py
+++ b/conda-tree.py
@@ -302,7 +302,7 @@ def main():
     if args.prefix is None:
         _conda = os.environ.get('CONDA_EXE', 'conda')
         _info = json.loads(subprocess.check_output(
-            [_conda, 'info', '-e', '--json']))
+            [_conda, 'info', '--json']))
         if args.name is None:
             if _info['active_prefix'] is not None:
                 args.prefix = _info['active_prefix']


### PR DESCRIPTION
After `conda` release 25.11.0, `conda info --envs --json` only gets the conda envs list, which results in the `KeyError` (see https://github.com/conda-incubator/conda-tree/issues/27). It can be fixed by simply removing '-e' option when calling `conda info`.